### PR TITLE
pashov-fix/C-02

### DIFF
--- a/src/BunniHook.sol
+++ b/src/BunniHook.sol
@@ -377,6 +377,11 @@ contract BunniHook is BaseHook, Ownable, IBunniHook, ReentrancyGuard, AmAmm {
         return block.timestamp > s.rebalanceOrderDeadline[id];
     }
 
+    /// @inheritdoc IBunniHook
+    function getModifiers() external view returns (uint32 hookFeeModifier_, uint32 referralRewardModifier_) {
+        return (hookFeeModifier, referralRewardModifier);
+    }
+
     /// -----------------------------------------------------------------------
     /// Hooks
     /// -----------------------------------------------------------------------

--- a/src/interfaces/IBunniHook.sol
+++ b/src/interfaces/IBunniHook.sol
@@ -164,6 +164,9 @@ interface IBunniHook is IBaseHook, IOwnable, IUnlockCallback, IERC1271, IAmAmm {
     /// @return Whether liquidity can be withdrawn from the given pool.
     function canWithdraw(PoolId id) external view returns (bool);
 
+    /// @notice Returns the modifiers for computing hook fee and referral reward
+    function getModifiers() external view returns (uint32 hookFeeModifier_, uint32 referralRewardModifier_);
+
     /// -----------------------------------------------------------------------
     /// External functions
     /// -----------------------------------------------------------------------

--- a/src/periphery/BunniQuoter.sol
+++ b/src/periphery/BunniQuoter.sol
@@ -30,12 +30,10 @@ import {LiquidityAmounts} from "../lib/LiquidityAmounts.sol";
 
 contract BunniQuoter is IBunniQuoter {
     using TickMath for *;
-    using SafeCastLib for int256;
-    using SafeCastLib for uint256;
+    using SafeCastLib for *;
+    using FixedPointMathLib for *;
     using HookletLib for IHooklet;
     using PoolIdLibrary for PoolKey;
-    using FixedPointMathLib for int256;
-    using FixedPointMathLib for uint256;
 
     IBunniHub internal immutable hub;
 
@@ -113,8 +111,7 @@ contract BunniQuoter is IBunniQuoter {
         // get TWAP values
         int24 arithmeticMeanTick = bunniState.twapSecondsAgo != 0 ? queryTwap(key, bunniState.twapSecondsAgo) : int24(0);
         int24 feeMeanTick = (
-            !feeOverridden && !hookParams.amAmmEnabled && hookParams.feeMin != hookParams.feeMax
-                && hookParams.feeQuadraticMultiplier != 0
+            !feeOverridden && hookParams.feeMin != hookParams.feeMax && hookParams.feeQuadraticMultiplier != 0
         ) ? queryTwap(key, hookParams.feeTwapSecondsAgo) : int24(0);
 
         // query the LDF to get total liquidity and token densities
@@ -208,6 +205,23 @@ contract BunniQuoter is IBunniQuoter {
         // 3) dynamic fee
         uint256 swapFeeAmount;
         bool useAmAmmFee = hookParams.amAmmEnabled && amAmmManager != address(0);
+        // swap fee used as the basis for computing hookFees when useAmAmmFee == true
+        // this is to avoid a malicious am-AMM manager bypassing hookFees
+        // by setting the swap fee to max and offering a proxy swap contract
+        // that sets the Bunni swap fee to 0 during such swaps and charging swap fees
+        // independently
+        uint24 hookFeesBaseSwapFee = feeOverridden
+            ? feeOverride
+            : computeDynamicSwapFee(
+                updatedSqrtPriceX96,
+                feeMeanTick,
+                lastSurgeTimestamp,
+                hookParams.feeMin,
+                hookParams.feeMax,
+                hookParams.feeQuadraticMultiplier,
+                hookParams.surgeFee,
+                hookParams.surgeFeeHalfLife
+            );
         swapFee = useAmAmmFee
             ? (
                 amAmmEnableSurgeFee
@@ -218,22 +232,21 @@ contract BunniQuoter is IBunniQuoter {
                     )
                     : amAmmSwapFee
             )
-            : (
-                feeOverridden
-                    ? feeOverride
-                    : computeDynamicSwapFee(
-                        updatedSqrtPriceX96,
-                        feeMeanTick,
-                        lastSurgeTimestamp,
-                        hookParams.feeMin,
-                        hookParams.feeMax,
-                        hookParams.feeQuadraticMultiplier,
-                        hookParams.surgeFee,
-                        hookParams.surgeFeeHalfLife
-                    )
-            );
+            : hookFeesBaseSwapFee;
         if (exactIn) {
+            // compute the swap fee and the hook fee (i.e. protocol fee)
+            // swap fee is taken by decreasing the output amount
             swapFeeAmount = outputAmount.mulDivUp(swapFee, SWAP_FEE_BASE);
+            if (useAmAmmFee) {
+                // instead of computing hook fees as a portion of the swap fee
+                // and deducting it, we compute hook fees separately using hookFeesBaseSwapFee
+                // and charge it as an extra fee on the swap
+                (uint32 hookFeeModifier,) = hook.getModifiers();
+                uint256 hookFeesAmount =
+                    outputAmount.mulDivUp(hookFeesBaseSwapFee, SWAP_FEE_BASE).mulDivUp(hookFeeModifier, MODIFIER_BASE);
+                swapFeeAmount += hookFeesAmount; // add hook fees to swapFeeAmount since we're only using it for computing inputAmount
+                swapFee += uint24(hookFeesBaseSwapFee.mulDivUp(hookFeeModifier, MODIFIER_BASE)); // modify effective swap fee for swapper
+            }
             outputAmount -= swapFeeAmount;
 
             // take in max(amountSpecified, inputAmount) such that if amountSpecified is greater we just happily accept it
@@ -244,6 +257,16 @@ contract BunniQuoter is IBunniQuoter {
             // need to modify fee rate to maintain the same average price as exactIn case
             // in / (out * (1 - fee)) = in * (1 + fee') / out => fee' = fee / (1 - fee)
             swapFeeAmount = inputAmount.mulDivUp(swapFee, SWAP_FEE_BASE - swapFee);
+            if (useAmAmmFee) {
+                // instead of computing hook fees as a portion of the swap fee
+                // and deducting it, we compute hook fees separately using hookFeesBaseSwapFee
+                // and charge it as an extra fee on the swap
+                (uint32 hookFeeModifier,) = hook.getModifiers();
+                uint256 hookFeesAmount = inputAmount.mulDivUp(hookFeesBaseSwapFee, SWAP_FEE_BASE - hookFeesBaseSwapFee)
+                    .mulDivUp(hookFeeModifier, MODIFIER_BASE);
+                swapFeeAmount += hookFeesAmount; // add hook fees to swapFeeAmount since we're only using it for computing inputAmount
+                swapFee += uint24(hookFeesBaseSwapFee.mulDivUp(hookFeeModifier, MODIFIER_BASE)); // modify effective swap fee for swapper
+            }
             inputAmount += swapFeeAmount;
 
             // give out min(amountSpecified, outputAmount) such that if amountSpecified is greater we only give outputAmount and let the tx revert


### PR DESCRIPTION
Fix C-02 by setting `amAmmFeeAmount = swapFeeAmount;` after (and not before) `hookFeesAmount` has been deducted from `swapFeeAmount`.