### PR TITLE
pashov-fix/C-03

### DIFF
--- a/src/BunniHook.sol
+++ b/src/BunniHook.sol
@@ -195,6 +195,9 @@ contract BunniHook is BaseHook, Ownable, IBunniHook, ReentrancyGuard, AmAmm {
         // pull claim tokens from BunniHub
         hub.hookHandleSwap({key: key, zeroForOne: zeroForOne, inputAmount: 0, outputAmount: amount});
 
+        // lock BunniHub to prevent reentrancy
+        hub.lockForRebalance(key);
+
         // burn and take
         poolManager.burn(address(this), currency.toId(), amount);
         poolManager.take(currency, address(this), amount);
@@ -217,6 +220,9 @@ contract BunniHook is BaseHook, Ownable, IBunniHook, ReentrancyGuard, AmAmm {
         // settle the transferred tokens and mint claim tokens
         uint256 paid = poolManager.settle{value: currency.isNative() ? amount : 0}();
         poolManager.mint(address(this), currency.toId(), paid);
+
+        // unlock BunniHub
+        hub.unlockForRebalance(key);
 
         // push claim tokens to BunniHub
         hub.hookHandleSwap({key: key, zeroForOne: zeroForOne, inputAmount: paid, outputAmount: 0});

--- a/src/BunniHub.sol
+++ b/src/BunniHub.sol
@@ -236,6 +236,20 @@ contract BunniHub is IBunniHub, Permit2Enabled, Ownable {
         }
     }
 
+    /// @inheritdoc IBunniHub
+    function lockForRebalance(PoolKey calldata key) external {
+        if (address(_getBunniTokenOfPool(key.toId())) == address(0)) revert BunniHub__BunniTokenNotInitialized();
+        if (msg.sender != address(key.hooks)) revert BunniHub__Unauthorized();
+        _nonReentrantBefore();
+    }
+
+    /// @inheritdoc IBunniHub
+    function unlockForRebalance(PoolKey calldata key) external {
+        if (address(_getBunniTokenOfPool(key.toId())) == address(0)) revert BunniHub__BunniTokenNotInitialized();
+        if (msg.sender != address(key.hooks)) revert BunniHub__Unauthorized();
+        _nonReentrantAfter();
+    }
+
     receive() external payable {}
 
     /// -----------------------------------------------------------------------

--- a/src/interfaces/IBunniHub.sol
+++ b/src/interfaces/IBunniHub.sol
@@ -265,6 +265,14 @@ interface IBunniHub is IUnlockCallback, IPermit2Enabled, IOwnable {
     /// @param referrerAddress The address of the referrer
     function setReferrerAddress(uint24 referrer, address referrerAddress) external;
 
+    /// @notice Called by key.hooks to lock BunniHub before a rebalance order's execution.
+    /// @param key The PoolKey of the Uniswap v4 pool
+    function lockForRebalance(PoolKey calldata key) external;
+
+    /// @notice Called by key.hooks to unlock BunniHub after a rebalance order's execution.
+    /// @param key The PoolKey of the Uniswap v4 pool
+    function unlockForRebalance(PoolKey calldata key) external;
+
     /// @notice The state of a Bunni pool.
     function poolState(PoolId poolId) external view returns (PoolState memory);
 


### PR DESCRIPTION
Fix C-03 by adding `BunniHub.lockForRebalance()` and `BunniHub.unlockForRebalance()` to lock `BunniHub` functions during the execution of a rebalance order. This prevents reentrancy attacks during rebalance order execution.