### PR TITLE
pashov-fix/H-07

### DIFF
--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -720,7 +720,7 @@ library BunniHookLogic {
             offer: offer,
             consideration: consideration,
             deadline: block.timestamp + rebalanceOrderTTL,
-            nonce: block.number,
+            nonce: uint256(keccak256(abi.encode(block.number, id))), // combine block.number and pool id to avoid nonce collisions between pools
             preHooks: preHooks,
             postHooks: postHooks
         });


### PR DESCRIPTION
Fix H-07 by using a combo of block number and pool id as the permit2 nonce in flood orders to avoid nonce collision between pools in the same block.