### PR TITLE
pashov-fix/H-03

### DIFF
--- a/src/BunniHook.sol
+++ b/src/BunniHook.sol
@@ -366,6 +366,11 @@ contract BunniHook is BaseHook, Ownable, IBunniHook, ReentrancyGuard, AmAmm {
         return (prices.initialized, prices.sharePrice0, prices.sharePrice1);
     }
 
+    /// @inheritdoc IBunniHook
+    function getModifiers() external view returns (uint32 hookFeeModifier_, uint32 referralRewardModifier_) {
+        return (hookFeeModifier, referralRewardModifier);
+    }
+
     /// -----------------------------------------------------------------------
     /// Hooks
     /// -----------------------------------------------------------------------

--- a/src/interfaces/IBunniHook.sol
+++ b/src/interfaces/IBunniHook.sol
@@ -166,6 +166,9 @@ interface IBunniHook is IBaseHook, IOwnable, IUnlockCallback, IERC1271, IAmAmm {
     /// @notice Whether am-AMM is enabled for the given pool.
     function getAmAmmEnabled(PoolId id) external view returns (bool);
 
+    /// @notice Returns the modifiers for computing hook fee and referral reward
+    function getModifiers() external view returns (uint32 hookFeeModifier_, uint32 referralRewardModifier_);
+
     /// -----------------------------------------------------------------------
     /// External functions
     /// -----------------------------------------------------------------------


### PR DESCRIPTION
Use dynamic swap fee as the base fee when computing the hook fee (i.e. protocol fee) amount when an am-AMM exists for a pool. This prevents an am-AMM manager from bypassing the protocol fee.