### PR TITLE
pashov-fix/L-06

### DIFF
--- a/src/lib/FeeMath.sol
+++ b/src/lib/FeeMath.sol
@@ -18,7 +18,7 @@ function computeSurgeFee(uint32 lastSurgeTimestamp, uint24 surgeFee, uint16 surg
     // compute surge fee
     // surge fee gets applied after the LDF shifts (if it's dynamic)
     unchecked {
-        uint256 timeSinceLastSurge = block.timestamp - lastSurgeTimestamp;
+        uint256 timeSinceLastSurge = uint32(block.timestamp) - lastSurgeTimestamp;
         fee = uint24(
             uint256(surgeFee).mulWadUp(
                 uint256((-int256(timeSinceLastSurge.mulDiv(LN2_WAD, surgeFeeHalfLife))).expWad())


### PR DESCRIPTION
Fix the wrong calculation of surge fee when `lastSurgeTimestamp` overflows `uint32`.