### PR TITLE
tob-fix/1

### DIFF
--- a/src/BunniToken.sol
+++ b/src/BunniToken.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.15;
 
 import {Clone} from "clones-with-immutable-args/Clone.sol";
 
+import {LibMulticaller} from "multicaller/LibMulticaller.sol";
+
 import "@uniswap/v4-core/src/types/Currency.sol";
 import {IPoolManager} from "@uniswap/v4-core/src/interfaces/IPoolManager.sol";
 import {IUnlockCallback} from "@uniswap/v4-core/src/interfaces/callback/IUnlockCallback.sol";
@@ -299,6 +301,19 @@ contract BunniToken is IBunniToken, ERC20Referrer, Clone, Ownable {
             }
         }
     }
+
+    /// -----------------------------------------------------------------------
+    /// EIP-2612
+    /// -----------------------------------------------------------------------
+
+    function incrementNonce() external override {
+        address msgSender = LibMulticaller.senderOrSigner();
+        _incrementNonce(msgSender);
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Internal utilities
+    /// -----------------------------------------------------------------------
 
     /// @dev Compute the updated unclaimed reward of a referrer
     function _updatedUnclaimedReward(

--- a/src/base/ERC20.sol
+++ b/src/base/ERC20.sol
@@ -272,6 +272,17 @@ abstract contract ERC20 is IERC20 {
     /// of `keccak256(bytes(name()))` if `name()` will never change.
     function _constantNameHash() internal view virtual returns (bytes32 result) {}
 
+    /// @dev For inheriting contracts to increment the nonce.
+    function _incrementNonce(address owner) internal virtual {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x0c, _NONCES_SLOT_SEED)
+            mstore(0x00, owner)
+            let nonceSlot := keccak256(0x0c, 0x20)
+            sstore(nonceSlot, add(1, sload(nonceSlot)))
+        }
+    }
+
     /// @dev Returns the current nonce for `owner`.
     /// This value is used to compute the signature for EIP-2612 permit.
     function nonces(address owner) public view virtual returns (uint256 result) {

--- a/src/interfaces/IBunniToken.sol
+++ b/src/interfaces/IBunniToken.sol
@@ -58,4 +58,7 @@ interface IBunniToken is IERC20, IERC20Referrer, IERC20Lockable, IOwnable, IUnlo
     /// @return reward0 The amount of token0 rewards claimable
     /// @return reward1 The amount of token1 rewards claimable
     function getClaimableReferralRewards(uint24 referrer) external view returns (uint256 reward0, uint256 reward1);
+
+    /// @notice Increments the EIP-2612 permit nonce of the caller to invalidate permit signatures.
+    function incrementNonce() external;
 }


### PR DESCRIPTION
Add `BunniToken::incrementNonce` to enable invalidating permit signatures in case a malicious signature was signed.