### PR TITLE
tob-fix/9

### DIFF
--- a/src/BunniHook.sol
+++ b/src/BunniHook.sol
@@ -366,6 +366,11 @@ contract BunniHook is BaseHook, Ownable, IBunniHook, ReentrancyGuard, AmAmm {
         return (prices.initialized, prices.sharePrice0, prices.sharePrice1);
     }
 
+    /// @inheritdoc IBunniHook
+    function canWithdraw(PoolId id) external view returns (bool) {
+        return block.timestamp > s.rebalanceOrderDeadline[id];
+    }
+
     /// -----------------------------------------------------------------------
     /// Hooks
     /// -----------------------------------------------------------------------

--- a/src/base/Errors.sol
+++ b/src/base/Errors.sol
@@ -10,6 +10,7 @@ error BunniHub__InvalidReferrer();
 error BunniHub__LDFCannotBeZero();
 error BunniHub__MaxNonceReached();
 error BunniHub__SlippageTooHigh();
+error BunniHub__WithdrawalPaused();
 error BunniHub__HookCannotBeZero();
 error BunniHub__ZeroSharesMinted();
 error BunniHub__InvalidLDFParams();

--- a/src/interfaces/IBunniHook.sol
+++ b/src/interfaces/IBunniHook.sol
@@ -166,6 +166,12 @@ interface IBunniHook is IBaseHook, IOwnable, IUnlockCallback, IERC1271, IAmAmm {
     /// @notice Whether am-AMM is enabled for the given pool.
     function getAmAmmEnabled(PoolId id) external view returns (bool);
 
+    /// @notice Whether liquidity can be withdrawn from the given pool.
+    /// Currently used for pausing withdrawals when there is an active rebalance order.
+    /// @param id The pool id
+    /// @return Whether liquidity can be withdrawn from the given pool.
+    function canWithdraw(PoolId id) external view returns (bool);
+
     /// -----------------------------------------------------------------------
     /// External functions
     /// -----------------------------------------------------------------------

--- a/src/interfaces/IBunniQuoter.sol
+++ b/src/interfaces/IBunniQuoter.sol
@@ -29,5 +29,5 @@ interface IBunniQuoter {
     function quoteWithdraw(IBunniHub.WithdrawParams calldata params)
         external
         view
-        returns (uint256 amount0, uint256 amount1);
+        returns (bool success, uint256 amount0, uint256 amount1);
 }

--- a/src/lib/BunniHubLogic.sol
+++ b/src/lib/BunniHubLogic.sol
@@ -364,6 +364,10 @@ library BunniHubLogic {
             revert BunniHub__NeedToUseQueuedWithdrawal();
         }
 
+        if (!hook.canWithdraw(poolId)) {
+            revert BunniHub__WithdrawalPaused();
+        }
+
         /// -----------------------------------------------------------------------
         /// Hooklet call
         /// -----------------------------------------------------------------------

--- a/src/periphery/BunniQuoter.sol
+++ b/src/periphery/BunniQuoter.sol
@@ -300,10 +300,15 @@ contract BunniQuoter is IBunniQuoter {
         external
         view
         override
-        returns (uint256 amount0, uint256 amount1)
+        returns (bool success, uint256 amount0, uint256 amount1)
     {
         PoolId poolId = params.poolKey.toId();
         PoolState memory state = hub.poolState(poolId);
+        IBunniHook hook = IBunniHook(address(params.poolKey.hooks));
+
+        if (!hook.canWithdraw(poolId)) {
+            return (false, 0, 0);
+        }
 
         uint256 currentTotalSupply = state.bunniToken.totalSupply();
 


### PR DESCRIPTION
Pause withdrawals when a rebalance order is active. This prevents the rebalance order from making the pool more out of balance after the order is executed, which happens when liquidity is withdrawn after the order is created but before the order is executed.