### PR TITLE
tob-fix/4

### DIFF
--- a/src/base/SharedStructs.sol
+++ b/src/base/SharedStructs.sol
@@ -60,6 +60,7 @@ struct HubStorage {
 /// @member amAmmEnabled Whether the am-AMM is enabled for this pool
 /// @member oracleMinInterval The minimum interval between TWAP oracle updates, in seconds
 /// @member maxAmAmmFee The maximum swap fee that can be set by the am-AMM manager. Must <= MAX_AMAMM_FEE.
+/// @member minRentMultiplier The multiplier applied to the BunniToken total supply to compute the minimum rent. 18 decimals. Must be > 0 unless amAmmEnabled == false.
 struct DecodedHookParams {
     uint24 feeMin;
     uint24 feeMax;
@@ -77,6 +78,7 @@ struct DecodedHookParams {
     bool amAmmEnabled;
     uint32 oracleMinInterval;
     uint24 maxAmAmmFee;
+    uint48 minRentMultiplier;
 }
 
 /// @notice Contains mappings used by both BunniHook and BunniLogic. Makes passing

--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -801,7 +801,7 @@ library BunniHookLogic {
     function _decodeParams(bytes memory hookParams) internal pure returns (DecodedHookParams memory p) {
         // | feeMin - 3 bytes | feeMax - 3 bytes | feeQuadraticMultiplier - 3 bytes | feeTwapSecondsAgo - 3 bytes | surgeFee - 3 bytes | surgeFeeHalfLife - 2 bytes | surgeFeeAutostartThreshold - 2 bytes | vaultSurgeThreshold0 - 2 bytes | vaultSurgeThreshold1 - 2 bytes | rebalanceThreshold - 2 bytes | rebalanceMaxSlippage - 2 bytes | rebalanceTwapSecondsAgo - 2 bytes | rebalanceOrderTTL - 2 bytes | amAmmEnabled - 1 byte |
         bytes32 firstWord;
-        // | oracleMinInterval - 4 bytes |
+        // | oracleMinInterval - 4 bytes | maxAmAmmFee - 3 bytes | minRentMultiplier - 6 bytes |
         bytes32 secondWord;
         /// @solidity memory-safe-assembly
         assembly {
@@ -824,5 +824,6 @@ library BunniHookLogic {
         p.amAmmEnabled = uint8(bytes1(firstWord << 248)) != 0;
         p.oracleMinInterval = uint32(bytes4(secondWord));
         p.maxAmAmmFee = uint24(bytes3(secondWord << 32));
+        p.minRentMultiplier = uint48(bytes6(secondWord << 56));
     }
 }

--- a/test/BunniHub.t.sol
+++ b/test/BunniHub.t.sol
@@ -98,6 +98,7 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
     uint16 internal constant REBALANCE_ORDER_TTL = 10 minutes;
     uint32 internal constant ORACLE_MIN_INTERVAL = 1 hours;
     uint24 internal constant POOL_MAX_AMAMM_FEE = 0.05e6; // 5%
+    uint48 internal constant MIN_RENT_MULTIPLIER = 1e10;
     uint256 internal constant HOOK_FLAGS = Hooks.AFTER_INITIALIZE_FLAG + Hooks.BEFORE_ADD_LIQUIDITY_FLAG
         + Hooks.BEFORE_SWAP_FLAG + Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG;
 
@@ -1096,7 +1097,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
             REBALANCE_ORDER_TTL,
             true, // amAmmEnabled
             ORACLE_MIN_INTERVAL,
-            POOL_MAX_AMAMM_FEE
+            POOL_MAX_AMAMM_FEE,
+            MIN_RENT_MULTIPLIER
         );
 
         bytes32 name_ = bytes32(bytes(name));
@@ -1177,6 +1179,7 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
         assertTrue(p.amAmmEnabled, "amAmmEnabled incorrect");
         assertEq(p.oracleMinInterval, ORACLE_MIN_INTERVAL, "oracleMinInterval incorrect");
         assertEq(p.maxAmAmmFee, POOL_MAX_AMAMM_FEE, "maxAmAmmFee incorrect");
+        assertEq(p.minRentMultiplier, MIN_RENT_MULTIPLIER, "minRentMultiplier incorrect");
     }
 
     function test_hookHasInsufficientTokens() external {
@@ -1255,7 +1258,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1354,7 +1358,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1456,7 +1461,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1606,7 +1612,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 amAmmEnabled,
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1685,7 +1692,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1760,7 +1768,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
 
@@ -1894,7 +1903,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 poolEnabled, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             )
         );
         PoolId id = key.toId();
@@ -2190,7 +2200,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             ),
             salt
         );
@@ -2227,7 +2238,8 @@ contract BunniHubTest is Test, GasSnapshot, Permit2Deployer, FloodDeployer {
                 REBALANCE_ORDER_TTL,
                 true, // amAmmEnabled
                 ORACLE_MIN_INTERVAL,
-                POOL_MAX_AMAMM_FEE
+                POOL_MAX_AMAMM_FEE,
+                MIN_RENT_MULTIPLIER
             ),
             bytes32(0)
         );

--- a/test/BunniToken.t.sol
+++ b/test/BunniToken.t.sol
@@ -55,6 +55,8 @@ contract BunniTokenTest is Test, Permit2Deployer, FloodDeployer, IUnlockCallback
     uint16 internal constant REBALANCE_TWAP_SECONDS_AGO = 1 hours;
     uint16 internal constant REBALANCE_ORDER_TTL = 10 minutes;
     uint32 internal constant ORACLE_MIN_INTERVAL = 1 hours;
+    uint24 internal constant POOL_MAX_AMAMM_FEE = 0.05e6; // 5%
+    uint48 internal constant MIN_RENT_MULTIPLIER = 1e10;
     uint256 internal constant HOOK_FLAGS = Hooks.AFTER_INITIALIZE_FLAG + Hooks.BEFORE_ADD_LIQUIDITY_FLAG
         + Hooks.BEFORE_SWAP_FLAG + Hooks.BEFORE_SWAP_RETURNS_DELTA_FLAG;
     uint256 internal constant MAX_REL_ERROR = 1e4;
@@ -136,7 +138,8 @@ contract BunniTokenTest is Test, Permit2Deployer, FloodDeployer, IUnlockCallback
             REBALANCE_ORDER_TTL,
             true, // amAmmEnabled
             ORACLE_MIN_INTERVAL,
-            MAX_AMAMM_FEE
+            POOL_MAX_AMAMM_FEE,
+            MIN_RENT_MULTIPLIER
         );
         (bunniToken, key) = hub.deployBunniToken(
             IBunniHub.DeployBunniTokenParams({


### PR DESCRIPTION
Override `AmAmm::MIN_RENT` setting it to a proportion of the `BunniToken` total supply.

Note: based on changes in tob-fix/11