### PR TITLE
Add exactIn to swap event

### DIFF
--- a/src/interfaces/IBunniHook.sol
+++ b/src/interfaces/IBunniHook.sol
@@ -45,6 +45,7 @@ interface IBunniHook is IBaseHook, IOwnable, IUnlockCallback, IERC1271, IAmAmm {
     event Swap(
         PoolId indexed id,
         address indexed sender,
+        bool exactIn,
         bool zeroForOne,
         uint256 inputAmount,
         uint256 outputAmount,

--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -463,6 +463,7 @@ library BunniHookLogic {
         emit IBunniHook.Swap(
             id,
             sender,
+            exactIn,
             params.zeroForOne,
             inputAmount,
             outputAmount,


### PR DESCRIPTION
Swap fees are take from the input or output token depending on whether the swap is an exactIn or exactOut swap. In order to correctly track swap fees, and subsequently display swap APY in the UI, the swap event must emit the value for exactIn. Without it, we cannot reliably track swap fees. This PR addresses that issue.