### PR TITLE
tob-fix/ldf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ out/
 .env
 
 .vscode
+medusa/
+crytic-export/

--- a/fuzz/FuzzLDF.sol
+++ b/fuzz/FuzzLDF.sol
@@ -15,11 +15,11 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
     uint256 geometric_dist_1_failures;
 
     // Invariant: Given a valid cumulative amount of token0, the cumulative amount calculated
-    //            using the rounded tick from inverseCommulativeAmount0() should be less than
+    //            using the rounded tick from inverseCommulativeAmount0() should be greater than
     //            or equal to the specified cumulative amount for UniformDistribution in rounded
     //            ticks [roundedTick, tickUpper).
     // Issue: TOB-BUNNI-19
-    function inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+    function inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
         int24 tickSpacing,
         uint256 totalLiquidity,
         uint256 cumulativeAmount0,
@@ -91,10 +91,10 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
                 tickUpper
             );
 
-        assertLte(
-            _subError(resultCumulativeAmount0, INVCUM0_MAX_ERROR),
+        assertGte(
+            resultCumulativeAmount0,
             cumulativeAmount0,
-            "resultCumulativeAmount0 > cumulativeAmount0"
+            "resultCumulativeAmount0 < cumulativeAmount0"
         );
     }
     // Invariant: Given a valid cumulative amount of token1, the cumulative amount calculated
@@ -185,7 +185,7 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
     //            using the rounded tick from inverseCommulativeAmount0() should be less than
     //            or equal to the specified cumulative amount for GeometricDistribution in rounded
     //            ticks [roundedTick, tickUpper).
-    function inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_geometric_distribution(
+    function inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_geometric_distribution(
         int24 tickSpacing,
         uint256 totalLiquidity,
         uint256 cumulativeAmount0,
@@ -265,10 +265,10 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
                 length,
                 alphaX96
             );
-        assertLte(
-            _subError(resultCumulativeAmount0, INVCUM0_MAX_ERROR),
+        assertGte(
+            resultCumulativeAmount0,
             cumulativeAmount0,
-            "resultCumulativeAmount0 > cumulativeAmount0"
+            "resultCumulativeAmount0 < cumulativeAmount0"
         );
     }
 
@@ -372,7 +372,7 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
     //            using the rounded tick from inverseCommulativeAmount0() should be less than
     //            or equal to the specified cumulative amount for DoubleGeometricDistribution in rounded
     //            ticks [roundedTick, tickUpper).
-    function inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_double_geometric(
+    function inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_double_geometric(
         uint256 liquidity,
         uint256 cumulativeAmount0,
         int24 tickSpacing,
@@ -509,12 +509,10 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
                 weight1
             );
 
-        // NOTE: in rare cases resultCumulativeAmount0 may be slightly greater than cumulativeAmount0
-        // the frequency of such errors is bounded by INVCUM0_MAX_ERROR
-        assertLte(
-            _subError(resultCumulativeAmount0, INVCUM0_MAX_ERROR),
+        assertGte(
+            resultCumulativeAmount0,
             cumulativeAmount0,
-            "resultCumulativeAmount0 > cumulativeAmount0"
+            "resultCumulativeAmount0 < cumulativeAmount0"
         );
     }
 
@@ -669,7 +667,7 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
     //            using the rounded tick from inverseCommulativeAmount0() should be less than
     //            or equal to the specified cumulative amount for CarpetedGeometricDistribution in rounded
     //            ticks [roundedTick, tickUpper).
-    function inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+    function inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
         uint256 liquidity,
         uint256 cumulativeAmount0,
         int24 tickSpacing,
@@ -759,13 +757,10 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
                 weightCarpet
             );
 
-        // NOTE: in rare cases resultCumulativeAmount0 may be slightly greater than cumulativeAmount0
-        // the frequency of such errors is bounded by INVCUM0_MAX_ERROR
-
-        assertLte(
-            _subError(resultCumulativeAmount0, INVCUM0_MAX_ERROR),
+        assertGte(
+            resultCumulativeAmount0,
             cumulativeAmount0,
-            "resultCumulativeAmount0 > cumulativeAmount0"
+            "resultCumulativeAmount0 < cumulativeAmount0"
         );
     }
 
@@ -993,13 +988,10 @@ contract FuzzLDF is FuzzHelper, PropertiesAsserts {
                 params
             );
 
-        // NOTE: in rare cases resultCumulativeAmount0 may be slightly greater than cumulativeAmount0
-        // the frequency of such errors is bounded by INVCUM0_MAX_ERROR
-
-        assertLte(
-            _subError(resultCumulativeAmount0, INVCUM0_MAX_ERROR),
+        assertGte(
+            resultCumulativeAmount0,
             cumulativeAmount0,
-            "resultCumulativeAmount0 > cumulativeAmount0"
+            "resultCumulativeAmount0 < cumulativeAmount0"
         );
     }
 

--- a/fuzz/FuzzSwap.sol
+++ b/fuzz/FuzzSwap.sol
@@ -163,6 +163,12 @@ contract FuzzSwap is FuzzHelper, PropertiesAsserts {
             (uint160 updatedSqrtPriceX960, int24 updatedTick0, uint256 inputAmount1, uint256 outputAmount1) =
                 BunniSwapMath.computeSwap(input2);
 
+            console.log("amountSpecified", amountSpecified);
+            console.log("inputAmount0", inputAmount0);
+            console.log("outputAmount0", outputAmount0);
+            console.log("inputAmount1", inputAmount1);
+            console.log("outputAmount1", outputAmount1);
+
             if (amountSpecified < 0) {
                 assertWithMsg(inputAmount0 >= outputAmount1, "Round trips swaps are profitable");
             } else {

--- a/src/ldf/LibBuyTheDipGeometricDistribution.sol
+++ b/src/ldf/LibBuyTheDipGeometricDistribution.sol
@@ -130,7 +130,7 @@ library LibBuyTheDipGeometricDistribution {
     }
 
     /// @dev Given a cumulativeAmount0, computes the rounded tick whose cumulativeAmount0 is closest to the input. Range is [tickLower, tickUpper].
-    ///      The returned tick will be the smallest rounded tick whose cumulativeAmount0 is less than or equal to the input.
+    ///      The returned tick will be the largest rounded tick whose cumulativeAmount0 is greater than or equal to the input.
     ///      In the case that the input exceeds the cumulativeAmount0 of all rounded ticks, the function will return (false, 0).
     function inverseCumulativeAmount0(
         uint256 cumulativeAmount0_,
@@ -219,8 +219,8 @@ library LibBuyTheDipGeometricDistribution {
         if (exactIn == zeroForOne) {
             // compute roundedTick by inverting the cumulative amount
             // below is an illustration of 4 rounded ticks, the input amount, and the resulting roundedTick (rick)
-            // notice that the inverse tick is between two rounded ticks, and we round up to the rounded tick to the right
-            // e.g. go from 1.5 to 2
+            // notice that the inverse tick is between two rounded ticks, and we round down to the rounded tick to the left
+            // e.g. go from 1.5 to 1
             //       input
             //      ├──────┤
             // ┌──┬──┬──┬──┐
@@ -228,9 +228,9 @@ library LibBuyTheDipGeometricDistribution {
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             (success, roundedTick) = inverseCumulativeAmount0(
                 inverseCumulativeAmountInput,
                 totalLiquidity,
@@ -247,17 +247,17 @@ library LibBuyTheDipGeometricDistribution {
 
             // compute the cumulative amount up to roundedTick
             // below is an illustration of the cumulative amount at roundedTick
-            // notice that (input - cum) is the remainder of the swap that will be handled by Uniswap math
-            //         cum
-            //       ├─────┤
+            // notice that (cum - input) is the remainder of the swap that will be handled by Uniswap math
+            //       cum
+            //    ├────────┤
             // ┌──┬──┬──┬──┐
             // │  │ █│██│██│
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             cumulativeAmount = cumulativeAmount0(
                 roundedTick,
                 totalLiquidity,
@@ -273,7 +273,6 @@ library LibBuyTheDipGeometricDistribution {
 
             // compute liquidity of the rounded tick that will handle the remainder of the swap
             // below is an illustration of the liquidity of the rounded tick that will handle the remainder of the swap
-            // because we got rick by rounding up, the liquidity of (rick - tickSpacing) is used by the Uniswap math
             //    liq
             //    ├──┤
             // ┌──┬──┬──┬──┐
@@ -283,10 +282,10 @@ library LibBuyTheDipGeometricDistribution {
             // 0  1  2  3  4
             //    │
             //    ▼
-            //   rick - tickSpacing
+            //   rick
             swapLiquidity = (
                 liquidityDensityX96(
-                    roundedTick - tickSpacing,
+                    roundedTick,
                     tickSpacing,
                     twapTick,
                     minTick,

--- a/src/ldf/LibCarpetedGeometricDistribution.sol
+++ b/src/ldf/LibCarpetedGeometricDistribution.sol
@@ -105,7 +105,7 @@ library LibCarpetedGeometricDistribution {
     }
 
     /// @dev Given a cumulativeAmount0, computes the rounded tick whose cumulativeAmount0 is closest to the input. Range is [tickLower, tickUpper].
-    ///      The returned tick will be the smallest rounded tick whose cumulativeAmount0 is less than or equal to the input.
+    ///      The returned tick will be the largest rounded tick whose cumulativeAmount0 is greater than or equal to the input.
     ///      In the case that the input exceeds the cumulativeAmount0 of all rounded ticks, the function will return (false, 0).
     function inverseCumulativeAmount0(
         uint256 cumulativeAmount0_,
@@ -154,17 +154,9 @@ library LibCarpetedGeometricDistribution {
             } else if (leftCarpetLiquidity != 0) {
                 // use left carpet
                 remainder -= mainCumulativeAmount0;
-                console2.log("remainder", remainder);
 
                 (success, roundedTick) = LibUniformDistribution.inverseCumulativeAmount0(
                     remainder, leftCarpetLiquidity, tickSpacing, minUsableTick, minTick
-                );
-                console2.log("roundedTick", roundedTick);
-                console2.log(
-                    "cumulativeAmount",
-                    LibUniformDistribution.cumulativeAmount0(
-                        roundedTick, leftCarpetLiquidity, tickSpacing, minUsableTick, minTick
-                    )
                 );
                 return (success, roundedTick);
             }
@@ -298,8 +290,8 @@ library LibCarpetedGeometricDistribution {
         if (exactIn == zeroForOne) {
             // compute roundedTick by inverting the cumulative amount
             // below is an illustration of 4 rounded ticks, the input amount, and the resulting roundedTick (rick)
-            // notice that the inverse tick is between two rounded ticks, and we round up to the rounded tick to the right
-            // e.g. go from 1.5 to 2
+            // notice that the inverse tick is between two rounded ticks, and we round down to the rounded tick to the left
+            // e.g. go from 1.5 to 1
             //       input
             //      ├──────┤
             // ┌──┬──┬──┬──┐
@@ -307,9 +299,9 @@ library LibCarpetedGeometricDistribution {
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             (success, roundedTick) = inverseCumulativeAmount0(
                 inverseCumulativeAmountInput, totalLiquidity, tickSpacing, minTick, length, alphaX96, weightCarpet
             );
@@ -317,23 +309,22 @@ library LibCarpetedGeometricDistribution {
 
             // compute the cumulative amount up to roundedTick
             // below is an illustration of the cumulative amount at roundedTick
-            // notice that (input - cum) is the remainder of the swap that will be handled by Uniswap math
-            //         cum
-            //       ├─────┤
+            // notice that (cum - input) is the remainder of the swap that will be handled by Uniswap math
+            //       cum
+            //    ├────────┤
             // ┌──┬──┬──┬──┐
             // │  │ █│██│██│
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             cumulativeAmount =
                 cumulativeAmount0(roundedTick, totalLiquidity, tickSpacing, minTick, length, alphaX96, weightCarpet);
 
             // compute liquidity of the rounded tick that will handle the remainder of the swap
             // below is an illustration of the liquidity of the rounded tick that will handle the remainder of the swap
-            // because we got rick by rounding up, the liquidity of (rick - tickSpacing) is used by the Uniswap math
             //    liq
             //    ├──┤
             // ┌──┬──┬──┬──┐
@@ -343,10 +334,9 @@ library LibCarpetedGeometricDistribution {
             // 0  1  2  3  4
             //    │
             //    ▼
-            //   rick - tickSpacing
+            //   rick
             swapLiquidity = (
-                liquidityDensityX96(roundedTick - tickSpacing, tickSpacing, minTick, length, alphaX96, weightCarpet)
-                    * totalLiquidity
+                liquidityDensityX96(roundedTick, tickSpacing, minTick, length, alphaX96, weightCarpet) * totalLiquidity
             ) >> 96;
         } else {
             // compute roundedTick by inverting the cumulative amount

--- a/src/ldf/LibDoubleGeometricDistribution.sol
+++ b/src/ldf/LibDoubleGeometricDistribution.sol
@@ -121,7 +121,7 @@ library LibDoubleGeometricDistribution {
     }
 
     /// @dev Given a cumulativeAmount0, computes the rounded tick whose cumulativeAmount0 is closest to the input. Range is [tickLower, tickUpper].
-    ///      The returned tick will be the smallest rounded tick whose cumulativeAmount0 is less than or equal to the input.
+    ///      The returned tick will be the largest rounded tick whose cumulativeAmount0 is greater than or equal to the input.
     ///      In the case that the input exceeds the cumulativeAmount0 of all rounded ticks, the function will return (false, 0).
     function inverseCumulativeAmount0(
         uint256 cumulativeAmount0_,
@@ -291,8 +291,8 @@ library LibDoubleGeometricDistribution {
         if (exactIn == zeroForOne) {
             // compute roundedTick by inverting the cumulative amount
             // below is an illustration of 4 rounded ticks, the input amount, and the resulting roundedTick (rick)
-            // notice that the inverse tick is between two rounded ticks, and we round up to the rounded tick to the right
-            // e.g. go from 1.5 to 2
+            // notice that the inverse tick is between two rounded ticks, and we round down to the rounded tick to the left
+            // e.g. go from 1.5 to 1
             //       input
             //      ├──────┤
             // ┌──┬──┬──┬──┐
@@ -300,9 +300,9 @@ library LibDoubleGeometricDistribution {
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             (success, roundedTick) = inverseCumulativeAmount0(
                 inverseCumulativeAmountInput,
                 totalLiquidity,
@@ -319,17 +319,17 @@ library LibDoubleGeometricDistribution {
 
             // compute the cumulative amount up to roundedTick
             // below is an illustration of the cumulative amount at roundedTick
-            // notice that (input - cum) is the remainder of the swap that will be handled by Uniswap math
-            //         cum
-            //       ├─────┤
+            // notice that (cum - input) is the remainder of the swap that will be handled by Uniswap math
+            //       cum
+            //    ├────────┤
             // ┌──┬──┬──┬──┐
             // │  │ █│██│██│
             // │  │ █│██│██│
             // └──┴──┴──┴──┘
             // 0  1  2  3  4
-            //       │
-            //       ▼
-            //      rick
+            //    │
+            //    ▼
+            //   rick
             cumulativeAmount = cumulativeAmount0(
                 roundedTick,
                 totalLiquidity,
@@ -345,7 +345,6 @@ library LibDoubleGeometricDistribution {
 
             // compute liquidity of the rounded tick that will handle the remainder of the swap
             // below is an illustration of the liquidity of the rounded tick that will handle the remainder of the swap
-            // because we got rick by rounding up, the liquidity of (rick - tickSpacing) is used by the Uniswap math
             //    liq
             //    ├──┤
             // ┌──┬──┬──┬──┐
@@ -355,18 +354,10 @@ library LibDoubleGeometricDistribution {
             // 0  1  2  3  4
             //    │
             //    ▼
-            //   rick - tickSpacing
+            //   rick
             swapLiquidity = (
                 liquidityDensityX96(
-                    roundedTick - tickSpacing,
-                    tickSpacing,
-                    minTick,
-                    length0,
-                    length1,
-                    alpha0X96,
-                    alpha1X96,
-                    weight0,
-                    weight1
+                    roundedTick, tickSpacing, minTick, length0, length1, alpha0X96, alpha1X96, weight0, weight1
                 ) * totalLiquidity
             ) >> 96;
         } else {

--- a/src/lib/ExpMath.sol
+++ b/src/lib/ExpMath.sol
@@ -151,6 +151,71 @@ library ExpMath {
         }
     }
 
+    function lnQ96RoundingUp(int256 x) internal pure returns (int256 r) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Compute `k = log2(x) - 96`, `r = 159 - k = 255 - log2(x) = 255 ^ log2(x)`.
+            r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
+            r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))
+            r := or(r, shl(5, lt(0xffffffff, shr(r, x))))
+            r := or(r, shl(4, lt(0xffff, shr(r, x))))
+            r := or(r, shl(3, lt(0xff, shr(r, x))))
+            // We place the check here for more optimal stack operations.
+            if iszero(sgt(x, 0)) {
+                mstore(0x00, 0xe65fd7ca) // `LnQ96Undefined()`.
+                revert(0x1c, 0x04)
+            }
+            // forgefmt: disable-next-item
+            r := xor(r, byte(and(0x1f, shr(shr(r, x), 0x8421084210842108cc6318c6db6d54be)),
+                0xf8f9f9faf9fdfafbf9fdfcfdfafbfcfef9fafdfafcfcfbfefafafcfbffffffff))
+
+            // Reduce range of x to (1, 2) * 2**96
+            // ln(2^k * x) = k * ln(2) + ln(x)
+            x := shr(159, shl(r, x))
+
+            // Evaluate using a (8, 8)-term rational approximation.
+            // `p` is made monic, we will multiply by a scale factor later.
+            // forgefmt: disable-next-item
+            let p := sub( // This heavily nested expression is to avoid stack-too-deep for via-ir.
+                sar(96, mul(add(43456485725739037958740375743393,
+                sar(96, mul(add(24828157081833163892658089445524,
+                sar(96, mul(add(3273285459638523848632254066296,
+                    x), x))), x))), x)), 11111509109440967052023855526967)
+            p := sub(sar(96, mul(p, x)), 45023709667254063763336534515857)
+            p := sub(sar(96, mul(p, x)), 14706773417378608786704636184526)
+            p := sub(mul(p, x), shl(96, 795164235651350426258249787498))
+            // We leave `p` in `2**192` basis so we don't need to scale it back up for the division.
+
+            // `q` is monic by convention.
+            let q := add(5573035233440673466300451813936, x)
+            q := add(71694874799317883764090561454958, sar(96, mul(x, q)))
+            q := add(283447036172924575727196451306956, sar(96, mul(x, q)))
+            q := add(401686690394027663651624208769553, sar(96, mul(x, q)))
+            q := add(204048457590392012362485061816622, sar(96, mul(x, q)))
+            q := add(31853899698501571402653359427138, sar(96, mul(x, q)))
+            q := add(909429971244387300277376558375, sar(96, mul(x, q)))
+
+            // `p / q` is in the range `(0, 0.125) * 2**96`.
+
+            // Finalization, we need to:
+            // - Multiply by the scale factor `s = 5.549…`.
+            // - Add `k * ln(2)`.
+
+            // The q polynomial is known not to have zeros in the domain.
+            // No scaling required because p is already `2**96` too large.
+            p := sdiv(p, q)
+            // Multiply by the scaling factor: `s * 2**96`, base is now `2**192`.
+            p := mul(439668470185123797622540459591, p)
+            // Add `ln(2) * k * 2**192`.
+            // forgefmt: disable-next-item
+            p := add(mul(4350955369971217654477563090224794165364344896676135745069, sub(159, r)), p)
+            // Base conversion: div `2**96`.
+            r := sar(96, p)
+            // If p % 2**96 is not 0, we need to round up.
+            if and(p, 0xffffffffffffffffffffffff) { r := add(r, 1) }
+        }
+    }
+
     function getSqrtPriceAtTickWad(int256 tickWad) internal pure returns (uint160 sqrtRatioX96) {
         sqrtRatioX96 = uint256((HALF_LN_TICK_BASE_Q96 * tickWad / int256(WAD)).expQ96()).toUint160();
     }

--- a/src/lib/Math.sol
+++ b/src/lib/Math.sol
@@ -51,10 +51,13 @@ function weightedSum(uint256 value0, uint256 weight0, uint256 value1, uint256 we
 }
 
 /// @dev Converts xWad, the decimal index of a rounded tick scaled by WAD, to the corresponding rounded tick.
-/// Always rounds up.
-function xWadToRoundedTick(int256 xWad, int24 mu, int24 tickSpacing) pure returns (int24) {
+function xWadToRoundedTick(int256 xWad, int24 mu, int24 tickSpacing, bool roundUp) pure returns (int24) {
     int24 x = SafeCastLib.toInt24(xWad / int256(WAD));
-    if (xWad > 0 && xWad % int256(WAD) != 0) x++; // round towards positive infinity
+    if (roundUp) {
+        if (xWad > 0 && xWad % int256(WAD) != 0) x++; // round towards positive infinity
+    } else {
+        if (xWad < 0 && xWad % int256(WAD) != 0) x--; // round towards negative infinity
+    }
     return x * tickSpacing + mu;
 }
 

--- a/test/FuzzEntry_Medusa_Test.t.sol
+++ b/test/FuzzEntry_Medusa_Test.t.sol
@@ -17,13 +17,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
     // Reproduced from: medusa/test_results/1729174553707355000-3346fdb2-80fe-4c95-b714-303b62e4044e.json
 
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_0()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_0()
         public
     {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-8044348), uint256(0), uint256(576281249999999798786), int24(0), int24(4173256)
         );
     }
@@ -168,13 +168,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205243295000-90543c90-7c4e-4299-a59a-c6507848c292.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_9()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_9()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077353997656798091744496997),
             int24(4),
@@ -186,13 +186,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205242319000-9781790d-c31d-4499-82b8-1bfe255169c6.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_10()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_10()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077354493364797715801534196),
             int24(4),
@@ -222,13 +222,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205242858000-48a662fa-34e0-481c-95c4-6cf1f6bab52f.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_12()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_12()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(1000000000000000143),
             uint256(54457951835691968901522315156395788569184496573700077354337443688549216737438),
             int24(4),
@@ -240,13 +240,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205242577000-7f61c16b-67c2-46f5-b26a-450313872dd0.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_13()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_13()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077354074521226726445297454),
             int24(4),
@@ -276,13 +276,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553706973000-bfb1c642-9c04-462a-956f-586ccc0156a1.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_15()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_15(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-6442092), uint256(0), uint256(999999999999999713070312499999897776), int24(0), int24(-2)
         );
     }
@@ -413,13 +412,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553706768000-b846810e-e54f-4399-8985-142ee16d3e6e.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_23()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_23(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-369631), uint256(0), uint256(1000000000000000288265624999985142108), int24(0), int24(7699216)
         );
     }
@@ -531,13 +529,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205241977000-cf9a08f9-b865-4041-8115-b08e28ab01b3.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_30()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_30()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077354313062362579940014309),
             int24(4),
@@ -585,13 +583,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553707562000-965cfd75-774d-4bd7-8558-8185b94c84ae.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_33()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_33(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(8166983), uint256(0), uint256(18035156249998359432), int24(0), int24(3319435)
         );
     }
@@ -705,13 +702,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553705944000-df96018e-463a-4e03-89db-6e91944b068f.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_40()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_40(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(2036545), uint256(62500000000493732), uint256(72017578125001543495), int24(0), int24(7818264)
         );
     }
@@ -735,13 +731,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553706463000-3390d2fb-c20a-4a71-9545-72a422a68870.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_42()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_42(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(1244413),
             uint256(1000000000000000000000000003397219730),
             uint256(140624999994872292),
@@ -769,13 +764,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205243086000-e9112580-6054-49e2-aa54-32dd5c02f014.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_44()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_44()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077354245621319512860689549),
             int24(4),
@@ -787,13 +782,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205223277000-7b290f79-0bf4-42f5-830c-251200d63af3.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_45()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_45()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(1000000000000000143),
             uint256(54457951835691968901522315156395788569184496573700077354599428302905534606081),
             int24(4),
@@ -805,13 +800,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205243500000-5b4c81d1-fe9a-4b71-98ec-4de1a932d547.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_46()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_46()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(1000000000000000143),
             uint256(54457951835691968901522315156395788569184496573700077354322906316113036652894),
             int24(4),
@@ -823,13 +818,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553706998000-1dc879bc-8371-4ecb-ae61-0f595687996b.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_47()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_47(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-1553186), uint256(0), uint256(36035156249997790666), int24(0), int24(0)
         );
     }
@@ -853,13 +847,12 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553705559000-ad239336-6294-4599-bf33-051dd58d4a1d.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_49()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_49(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-1530461), uint256(0), uint256(1000000000000281249999999639871), int24(0), int24(-2496757)
         );
     }
@@ -883,13 +876,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205243768000-12fcf8bc-156d-4f4c-a88a-5cc88a59d847.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_51()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_51()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077353984311843841258457628),
             int24(4),
@@ -901,13 +894,13 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729182205241488000-ac4112aa-b706-48bf-a94b-943a7a2bb86d.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric_52()
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric_52()
         public
     {
         vm.warp(block.timestamp + 314084);
         vm.roll(block.number + 21);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_carpeted_geometric(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_carpeted_geometric(
             uint256(143),
             uint256(54457951835691968901522315156395788569184496573700077354683014463446967340639),
             int24(4),
@@ -991,25 +984,23 @@ contract FuzzEntry_Medusa_Test is Test {
     }
 
     // Reproduced from: medusa/test_results/1729174553706952000-8ac3fe11-da05-43aa-ae86-9155ad6c4129.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_57()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_57(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(-3627023), uint256(0), uint256(999999999999999999281249999997839239), int24(0), int24(853805)
         );
     }
 
     // Reproduced from: medusa/test_results/1729174553703145000-e04ac006-edb9-4ee7-b53c-a7f3c010abbd.json
-    function test_auto_inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution_58()
-        public
-    {
+    function test_auto_inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution_58(
+    ) public {
         vm.warp(block.timestamp + 6603);
         vm.roll(block.number + 552);
         vm.prank(0x0000000000000000000000000000000000020000);
-        target.inverse_cummulative_amount0_less_than_equal_to_cummulative_amount0_in_uniform_distribution(
+        target.inverse_cummulative_amount0_greater_than_equal_to_cummulative_amount0_in_uniform_distribution(
             int24(376018), uint256(0), uint256(1000000000359406249999999719253), int24(0), int24(-849317)
         );
     }

--- a/test/ldf/LiquidityDensityFunctionTest.sol
+++ b/test/ldf/LiquidityDensityFunctionTest.sol
@@ -58,6 +58,14 @@ abstract contract LiquidityDensityFunctionTest is Test {
         key.tickSpacing = tickSpacing;
         (, uint256 cumulativeAmount0DensityX96, uint256 cumulativeAmount1DensityX96,,) =
             ldf.query(key, roundedTick, 0, currentTick, decodedLDFParams, LDF_STATE);
+        uint256 cumulativeAmount0 = ldf.cumulativeAmount0(
+            key, roundedTick + tickSpacing, FixedPoint96.Q96, 0, currentTick, decodedLDFParams, LDF_STATE
+        );
+        uint256 cumulativeAmount1 = ldf.cumulativeAmount1(
+            key, roundedTick - tickSpacing, FixedPoint96.Q96, 0, currentTick, decodedLDFParams, LDF_STATE
+        );
+        assertEq(cumulativeAmount0, cumulativeAmount0DensityX96, "cumulativeAmount0 incorrect");
+        assertEq(cumulativeAmount1, cumulativeAmount1DensityX96, "cumulativeAmount1 incorrect");
         uint256 bruteForceAmount0X96 =
             _bruteForceCumulativeAmount0Density(roundedTick + tickSpacing, tickSpacing, decodedLDFParams);
         uint256 bruteForceAmount1X96 =


### PR DESCRIPTION
Fix trail of bits audit issues 13, 19

fix: change `inverseCumulativeAmount0()` rounding direction, update `BunniSwapMath::computeSwap()` to use the new rounding direction, update `LDF::computeSwap()` to use the new rounding direction, fix LDF precision errors, correctly round values used in swaps to favor the pool