### PR TITLE
cyfrin-fix/L-03

### DIFF
--- a/src/ldf/LibBuyTheDipGeometricDistribution.sol
+++ b/src/ldf/LibBuyTheDipGeometricDistribution.sol
@@ -11,6 +11,7 @@ import "./LibGeometricDistribution.sol";
 import {LDFType} from "../types/LDFType.sol";
 
 library LibBuyTheDipGeometricDistribution {
+    using TickMath for *;
     using FixedPointMathLib for uint256;
 
     uint256 internal constant MIN_ALPHA = 1e3;
@@ -594,6 +595,11 @@ library LibBuyTheDipGeometricDistribution {
 
         // ensure alpha is in range
         if (alpha < MIN_ALPHA || alpha > MAX_ALPHA || alpha == ALPHA_BASE) return false;
+
+        // ensure alpha != sqrtRatioTickSpacing which would cause cum0 to always be 0
+        uint256 alphaX96 = alpha.mulDiv(Q96, ALPHA_BASE);
+        uint160 sqrtRatioTickSpacing = tickSpacing.getSqrtPriceAtTick();
+        if (alphaX96 == sqrtRatioTickSpacing) return false;
 
         // ensure the ticks are within the valid range
         if (shiftMode == uint8(ShiftMode.STATIC)) {


### PR DESCRIPTION
fix: add alpha != sqrtRatioTickSpacing check to LibBuyTheDipLDF::geometricIsValidParams()