### PR TITLE
cyfrin-fix/I-10

### DIFF
--- a/src/lib/LiquidityAmounts.sol
+++ b/src/lib/LiquidityAmounts.sol
@@ -1,18 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 
-import "@uniswap/v4-core/src/libraries/SqrtPriceMath.sol";
+import "./SqrtPriceMath.sol";
 
 /// @title Liquidity amount functions
 /// @notice Provides functions for computing liquidity amounts from token amounts and prices
 library LiquidityAmounts {
-    /// @notice Downcasts uint256 to uint128
-    /// @param x The uint258 to be downcasted
-    /// @return y The passed value, downcasted to uint128
-    function toUint128(uint256 x) private pure returns (uint128 y) {
-        require((y = uint128(x)) == x);
-    }
-
     /// @notice Computes the token0 and token1 value for a given amount of liquidity, the current
     /// pool prices and the prices at the tick boundaries
     /// @param sqrtRatioX96 A sqrt price representing the current pool prices
@@ -25,7 +18,7 @@ library LiquidityAmounts {
         uint160 sqrtRatioX96,
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96,
-        uint128 liquidity,
+        uint256 liquidity,
         bool roundingUp
     ) internal pure returns (uint256 amount0, uint256 amount1) {
         if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
@@ -38,36 +31,5 @@ library LiquidityAmounts {
         } else {
             amount1 = SqrtPriceMath.getAmount1Delta(sqrtRatioAX96, sqrtRatioBX96, liquidity, roundingUp);
         }
-    }
-
-    /// @notice Computes the amount of liquidity received for a given amount of token0 and price range
-    /// @dev Calculates amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
-    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
-    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
-    /// @param amount0 The amount0 being sent in
-    /// @return liquidity The amount of returned liquidity
-    function getLiquidityForAmount0(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint256 amount0)
-        internal
-        pure
-        returns (uint128 liquidity)
-    {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
-        uint256 intermediate = FullMath.mulDiv(sqrtRatioAX96, sqrtRatioBX96, FixedPoint96.Q96);
-        return toUint128(FullMath.mulDiv(amount0, intermediate, sqrtRatioBX96 - sqrtRatioAX96));
-    }
-
-    /// @notice Computes the amount of liquidity received for a given amount of token1 and price range
-    /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower)).
-    /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
-    /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
-    /// @param amount1 The amount1 being sent in
-    /// @return liquidity The amount of returned liquidity
-    function getLiquidityForAmount1(uint160 sqrtRatioAX96, uint160 sqrtRatioBX96, uint256 amount1)
-        internal
-        pure
-        returns (uint128 liquidity)
-    {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
-        return toUint128(FullMath.mulDiv(amount1, FixedPoint96.Q96, sqrtRatioBX96 - sqrtRatioAX96));
     }
 }

--- a/src/lib/QueryLDF.sol
+++ b/src/lib/QueryLDF.sol
@@ -75,7 +75,7 @@ function queryLDF(
     ) = ldf.query(key, roundedTick, arithmeticMeanTick, tick, ldfParams, ldfState);
 
     (uint256 density0OfRoundedTickX96, uint256 density1OfRoundedTickX96) = LiquidityAmounts.getAmountsForLiquidity(
-        sqrtPriceX96, roundedTickSqrtRatio, nextRoundedTickSqrtRatio, uint128(liquidityDensityOfRoundedTickX96), true
+        sqrtPriceX96, roundedTickSqrtRatio, nextRoundedTickSqrtRatio, liquidityDensityOfRoundedTickX96, true
     );
     totalDensity0X96 = density0RightOfRoundedTickX96 + density0OfRoundedTickX96;
     totalDensity1X96 = density1LeftOfRoundedTickX96 + density1OfRoundedTickX96;


### PR DESCRIPTION
fix: use custom SqrtPriceMath library for LiquidityAmounts instead of from v4-core