### PR TITLE
cyfrin-fix/G-05

### DIFF
--- a/src/ldf/LibCarpetedGeometricDistribution.sol
+++ b/src/ldf/LibCarpetedGeometricDistribution.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.19;
 import {SafeCastLib} from "solady/utils/SafeCastLib.sol";
 import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
+import {TickMath} from "@uniswap/v4-core/src/libraries/TickMath.sol";
+
 import "./ShiftMode.sol";
 import "../lib/Math.sol";
 import "../lib/ExpMath.sol";
@@ -131,6 +133,10 @@ library LibCarpetedGeometricDistribution {
         uint256 alphaX96,
         uint256 weightCarpet
     ) internal pure returns (bool success, int24 roundedTick) {
+        if (cumulativeAmount0_ == 0) {
+            return (true, TickMath.maxUsableTick(tickSpacing));
+        }
+
         // try LDFs in the order of right carpet, main, left carpet
         (
             uint256 leftCarpetLiquidity,
@@ -139,9 +145,6 @@ library LibCarpetedGeometricDistribution {
             int24 minUsableTick,
             int24 maxUsableTick
         ) = getCarpetedLiquidity(totalLiquidity, tickSpacing, minTick, length, weightCarpet);
-        if (cumulativeAmount0_ == 0) {
-            return (true, maxUsableTick);
-        }
         uint256 rightCarpetCumulativeAmount0 = LibUniformDistribution.cumulativeAmount0(
             minTick + length * tickSpacing,
             rightCarpetLiquidity,
@@ -197,6 +200,10 @@ library LibCarpetedGeometricDistribution {
         uint256 alphaX96,
         uint256 weightCarpet
     ) internal pure returns (bool success, int24 roundedTick) {
+        if (cumulativeAmount1_ == 0) {
+            return (true, TickMath.minUsableTick(tickSpacing) - tickSpacing);
+        }
+
         // try LDFs in the order of left carpet, main, right carpet
         (
             uint256 leftCarpetLiquidity,
@@ -205,9 +212,6 @@ library LibCarpetedGeometricDistribution {
             int24 minUsableTick,
             int24 maxUsableTick
         ) = getCarpetedLiquidity(totalLiquidity, tickSpacing, minTick, length, weightCarpet);
-        if (cumulativeAmount1_ == 0) {
-            return (true, minUsableTick - tickSpacing);
-        }
         uint256 leftCarpetCumulativeAmount1 = LibUniformDistribution.cumulativeAmount1(
             minTick, leftCarpetLiquidity, tickSpacing, minUsableTick, minTick, true
         );

--- a/src/ldf/LibGeometricDistribution.sol
+++ b/src/ldf/LibGeometricDistribution.sol
@@ -401,7 +401,7 @@ library LibGeometricDistribution {
 
         // ensure that roundedTick is not minTick + length * tickSpacing when cumulativeAmount0_ is non-zero
         // this can happen if the corresponding cumulative density is too small
-        if (roundedTick == maxTick && cumulativeAmount0_ != 0) {
+        if (roundedTick == maxTick) {
             return (true, maxTick - tickSpacing);
         }
     }
@@ -498,7 +498,7 @@ library LibGeometricDistribution {
 
         // ensure that roundedTick is not (minTick - tickSpacing) when cumulativeAmount1_ is non-zero and rounding up
         // this can happen if the corresponding cumulative density is too small
-        if (roundedTick == minTick - tickSpacing && cumulativeAmount1_ != 0) {
+        if (roundedTick == minTick - tickSpacing) {
             return (true, minTick);
         }
     }

--- a/src/ldf/LibUniformDistribution.sol
+++ b/src/ldf/LibUniformDistribution.sol
@@ -161,7 +161,7 @@ library LibUniformDistribution {
 
         // ensure that roundedTick is not tickUpper when cumulativeAmount0_ is non-zero
         // this can happen if the corresponding cumulative density is too small
-        if (roundedTick == tickUpper && cumulativeAmount0_ != 0) {
+        if (roundedTick == tickUpper) {
             return (true, tickUpper - tickSpacing);
         }
     }
@@ -210,7 +210,7 @@ library LibUniformDistribution {
 
         // ensure that roundedTick is not (tickLower - tickSpacing) when cumulativeAmount1_ is non-zero and rounding up
         // this can happen if the corresponding cumulative density is too small
-        if (roundedTick == tickLower - tickSpacing && cumulativeAmount1_ != 0) {
+        if (roundedTick == tickLower - tickSpacing) {
             return (true, tickLower);
         }
     }


### PR DESCRIPTION
gas: remove cumulativeAmount != 0 checks in LDFs where it's unnecessary, improve cumulativeAmount == 0 short circuits in carpeted LDFs