### PR TITLE
cyfrin-fix/M-08-new

### DIFF
--- a/src/lib/BunniHubLogic.sol
+++ b/src/lib/BunniHubLogic.sol
@@ -834,7 +834,7 @@ library BunniHubLogic {
 
         // validate vault fee value
         if (
-            vaultFee != 0 && dist(reserveChangeInUnderlying, postFeeAmount) > 1 // avoid reverting from normal rounding error
+            dist(reserveChangeInUnderlying, postFeeAmount) > 1 // avoid reverting from normal rounding error
                 && percentDelta(reserveChangeInUnderlying, postFeeAmount) > MAX_VAULT_FEE_ERROR
         ) {
             revert BunniHub__VaultFeeIncorrect();

--- a/test/BaseTest.sol
+++ b/test/BaseTest.sol
@@ -57,9 +57,9 @@ import {IBunniToken} from "../src/interfaces/IBunniToken.sol";
 import {OrderHashMemory} from "../src/lib/OrderHashMemory.sol";
 import {ReentrancyGuard} from "../src/base/ReentrancyGuard.sol";
 import {ERC4626WithFeeMock} from "./mocks/ERC4626WithFeeMock.sol";
-import {ERC4626Mock, MaliciousERC4626} from "./mocks/ERC4626Mock.sol";
 import {GeometricDistribution} from "../src/ldf/GeometricDistribution.sol";
 import {DoubleGeometricDistribution} from "../src/ldf/DoubleGeometricDistribution.sol";
+import {ERC4626Mock, MaliciousERC4626, ERC4626FeeMock} from "./mocks/ERC4626Mock.sol";
 import {ILiquidityDensityFunction} from "../src/interfaces/ILiquidityDensityFunction.sol";
 
 abstract contract BaseTest is Test, Permit2Deployer, FloodDeployer {

--- a/test/mocks/ERC4626Mock.sol
+++ b/test/mocks/ERC4626Mock.sol
@@ -93,3 +93,36 @@ contract MaliciousERC4626 is ERC4626 {
         }
     }
 }
+
+contract ERC4626FeeMock is ERC4626 {
+    address internal immutable _asset;
+    uint256 public fee;
+    uint256 internal constant MAX_FEE = 10000;
+
+    constructor(IERC20 asset_, uint256 _fee) {
+        _asset = address(asset_);
+        if (_fee > MAX_FEE) revert();
+        fee = _fee;
+    }
+
+    function setFee(uint256 newFee) external {
+        if (newFee > MAX_FEE) revert();
+        fee = newFee;
+    }
+
+    function deposit(uint256 assets, address to) public override returns (uint256 shares) {
+        return super.deposit(assets - assets * fee / MAX_FEE, to);
+    }
+
+    function asset() public view override returns (address) {
+        return _asset;
+    }
+
+    function name() public pure override returns (string memory) {
+        return "MockERC4626";
+    }
+
+    function symbol() public pure override returns (string memory) {
+        return "MOCK-ERC4626";
+    }
+}


### PR DESCRIPTION
fix: enforce vault fee check even when `vaultFee == 0` to avoid idleBalance manipulation & donation attacks