### PR TITLE
cyfrin-fix/M-11

### DIFF
--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -399,11 +399,16 @@ library BunniHookLogic {
                 hookFeesAmount = outputAmount.mulDivUp(hookFeesBaseSwapFee, SWAP_FEE_BASE).mulDivUp(
                     env.hookFeeModifier, MODIFIER_BASE
                 );
-
-                // it's possible that swapFeeAmount + hookFeesAmount > outputAmount
-                // in this case, we just take the entire output amount
-                if (swapFeeAmount + hookFeesAmount > outputAmount) {
-                    hookFeesAmount = outputAmount - swapFeeAmount;
+                // the case when swapFee = computeSurgeFee(lastSurgeTimestamp, hookParams.surgeFeeHalfLife)
+                if (swapFee != amAmmSwapFee) {
+                    // am-Amm manager's fee is in range [amAmmSwapFee, 100% - hookFeesBaseSwapFee.mulDivUp(env.hookFeeModifier, MODIFIER_BASE)]
+                    uint24 swapFeeAdjusted = uint24(
+                        FixedPointMathLib.max(
+                            amAmmSwapFee, swapFee - hookFeesBaseSwapFee.mulDivUp(env.hookFeeModifier, MODIFIER_BASE)
+                        )
+                    );
+                    // recalculate swapFeeAmount
+                    swapFeeAmount = outputAmount.mulDivUp(swapFeeAdjusted, SWAP_FEE_BASE);
                 }
             } else {
                 hookFeesAmount = swapFeeAmount.mulDivUp(env.hookFeeModifier, MODIFIER_BASE);

--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -399,6 +399,12 @@ library BunniHookLogic {
                 hookFeesAmount = outputAmount.mulDivUp(hookFeesBaseSwapFee, SWAP_FEE_BASE).mulDivUp(
                     env.hookFeeModifier, MODIFIER_BASE
                 );
+
+                // it's possible that swapFeeAmount + hookFeesAmount > outputAmount
+                // in this case, we just take the entire output amount
+                if (swapFeeAmount + hookFeesAmount > outputAmount) {
+                    hookFeesAmount = outputAmount - swapFeeAmount;
+                }
             } else {
                 hookFeesAmount = swapFeeAmount.mulDivUp(env.hookFeeModifier, MODIFIER_BASE);
                 swapFeeAmount -= hookFeesAmount;


### PR DESCRIPTION
fix: explicitly handle the case where `swapFeeAmount + hookFeesAmount > outputAmount` in `BunniHookLogic::beforeSwap()`