### PR TITLE
cyfrin-fix/I-20

### DIFF
--- a/src/ldf/LibCarpetedDoubleGeometricDistribution.sol
+++ b/src/ldf/LibCarpetedDoubleGeometricDistribution.sol
@@ -310,7 +310,7 @@ library LibCarpetedDoubleGeometricDistribution {
             }
             uint256 mainLiquidity = Q96.mulWad(WAD - params.weightCarpet);
             uint256 carpetLiquidity = Q96 - mainLiquidity;
-            return carpetLiquidity / uint24(numRoundedTicksCarpeted);
+            return carpetLiquidity.divUp(uint24(numRoundedTicksCarpeted));
         }
     }
 


### PR DESCRIPTION
fix: round up carpet liquidity in `LibCarpetedDoubleGeometricDistribution::liquidityDensityX96()` to be consistent with carpeted geometric