### PR TITLE
cyfrin-fix/fee-override-surge

### DIFF
--- a/src/lib/BunniHookLogic.sol
+++ b/src/lib/BunniHookLogic.sol
@@ -371,8 +371,9 @@ library BunniHookLogic {
         // by setting the swap fee to max and offering a proxy swap contract
         // that sets the Bunni swap fee to 0 during such swaps and charging swap fees
         // independently
+        // surge fee will still be applied if feeOverride is lower in order to protect LPs from MEV bots
         uint24 hookFeesBaseSwapFee = feeOverridden
-            ? feeOverride
+            ? uint24(FixedPointMathLib.max(feeOverride, computeSurgeFee(lastSurgeTimestamp, hookParams.surgeFeeHalfLife)))
             : computeDynamicSwapFee(
                 updatedSqrtPriceX96,
                 feeMeanTick,


### PR DESCRIPTION
# [Issue] Surge fee not used when hooklet overrides swap fee

When the hooklet of a pool overrides the swap fee via `IHooklet::beforeSwap()`  the override fee value is used directly as the swap fee (as long as an am-AMM manager doesn’t exist). This can easily lead to dagerous behavior where a surge occurs (e.g. from an LDF shift) but the surge fee is not applied due to the hooklet overriding the fee.

```solidity
 uint24 hookFeesBaseSwapFee = feeOverridden
    ? feeOverride // NOTE: Surge fee is not applied and `feeOverride` is used directly
    : computeDynamicSwapFee(
        updatedSqrtPriceX96,
        feeMeanTick,
        lastSurgeTimestamp,
        hookParams.feeMin,
        hookParams.feeMax,
        hookParams.feeQuadraticMultiplier,
        hookParams.surgeFeeHalfLife
    );
swapFee = useAmAmmFee
    ? uint24(FixedPointMathLib.max(amAmmSwapFee, computeSurgeFee(lastSurgeTimestamp, hookParams.surgeFeeHalfLife)))
    : hookFeesBaseSwapFee;
```

The fix is instead of using `feeOverride` directly, we use `FixedPointMathLib.max(feeOverride, computeSurgeFee(lastSurgeTimestamp, hookParams.surgeFeeHalfLife))` so that the surge fee is applied when needed.